### PR TITLE
管理画面で設定したサイト名が反映されるよう header.php を変更

### DIFF
--- a/Elements/header.php
+++ b/Elements/header.php
@@ -6,7 +6,7 @@
 
 <div class="base-header">
 <header class="mod-header"><div class="mod-header-inner">
-<h1 class="mod-header-sitetitle">basercart</h1>
+<h1 class="mod-header-sitetitle"><?php $this->BcBaser->link($this->BcBaser->siteConfig['name'] , '/') ?></h1>
 <p class="mod-header-cart"><?php echo $this->BcBaser->getGoodsLink('<i class="icon-shopping-cart"></i> お買いものかご'); ?></p>
 <div class="mod-header-figure <?php if(!$this->BcBaser->hasGoods()) { echo "noitem"; } ?>">
 <div class="mod-header-basket">


### PR DESCRIPTION
フォーラムの「[baserCart のWEBサイトタイトル](http://forum.basercms.net/modules/newbb/viewtopic.php?topic_id=1693&forum=5)」というトピックに

> リスのモリコママの左にある「basercart」の文字をお店の名前にしたいのです

という要望があったので、決めうちで「basercart」となっていた header.php を一部修正してみました。

何か意図があってタイトル固定とされてるならスルーしてくださってオッケイです ;-)
